### PR TITLE
Splash text

### DIFF
--- a/src/containers/NotesContainer/NotesContainer.js
+++ b/src/containers/NotesContainer/NotesContainer.js
@@ -16,8 +16,10 @@ export class NotesContainer extends Component {
   }
 
   render() {
+    let splashMessage = this.props.allNotes.length ? null : <h1 className="splash-message">Try Creating a New Note!</h1>
     return (
       <div className="NotesContainer">
+        { splashMessage }
         { this.props.allNotes && this.generateNotes() }
       </div>
     )

--- a/src/containers/NotesContainer/NotesContainer.scss
+++ b/src/containers/NotesContainer/NotesContainer.scss
@@ -15,8 +15,17 @@
     font-family: $font-Abel;
     box-shadow: 0 0 6px 3px #00000014;
   }
+
   h3 {
     color: #e0e0e0;
     margin: 0;
   }
+
+  .splash-message {
+    margin: 100px auto 0;
+    color: #75757580;
+    font-size: 80px;
+    width: 500px;
+  }
+  
 }


### PR DESCRIPTION
### Changes made:
- Added splash message that renders if notes array is empty
- Styled splash message

#### Before:
<img width="1499" alt="Screen Shot 2019-04-07 at 7 03 06 PM" src="https://user-images.githubusercontent.com/44077214/55692805-77081500-5968-11e9-811f-8435edb1fce0.png">

#### After:
<img width="1499" alt="Screen Shot 2019-04-07 at 7 02 50 PM" src="https://user-images.githubusercontent.com/44077214/55692808-7a9b9c00-5968-11e9-997c-f551ee7c8da4.png">
